### PR TITLE
Affine Cipher

### DIFF
--- a/src/Cipher/AffineCipher.js
+++ b/src/Cipher/AffineCipher.js
@@ -1,0 +1,17 @@
+const alphabets=require('../Alphabets');
+
+const AffineCipher = (text,a,b) => {
+    let cipher='';
+    text=text.toUpperCase();
+    text=text.replace(/[^A-Za-z]/g,"");
+    for(var i=0;i<text.length;i++) {
+        let val=text.charCodeAt(i)-65;
+        val=val * a;
+        val+=b;
+        val=val%26;
+        cipher+=String.fromCharCode(val+65);
+    }
+    return cipher;
+}
+
+module.exports=AffineCipher;

--- a/src/Cipher/AffineCipher.js
+++ b/src/Cipher/AffineCipher.js
@@ -1,6 +1,27 @@
 const alphabets=require('../Alphabets');
 
 const AffineCipher = (text,a,b) => {
+    /**
+     * 
+     * Encrypts data using two numeric values.  It is based on the formula (ax+b) mod m
+     * 
+     * Syntax:
+     *  AffineCipher(PlainText,a,b)
+     * 
+     * Parameters: 
+     *  text: String     // Plain Text for cipher
+     *  a: Number        // A number to encrypt the plain text
+     *  b: Number        // A number to encrypt the plain text
+     * 
+     * Returns:
+     *  Affine Cipher for the plain text with all upper case alphabets
+     * 
+     * Example:
+     *  AffineCipher("HELLOWORLD",5,3)         --> returns MXGGVJVKGS
+     *  AffineCipher("IAMPLAINTEXT",6,2)       --> returns YCWOQCYCMAKM
+     * 
+     */
+
     let cipher='';
     text=text.toUpperCase();
     text=text.replace(/[^A-Za-z]/g,"");

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -1,4 +1,7 @@
 module.exports.Alphabets=require('./Alphabets');
+
+//Ciphers
+module.exports.AffineCipher=require('./Cipher/AffineCipher');
 module.exports.DES=require('./Cipher/DES');
 module.exports.OneTimePad=require('./Cipher/OneTimePad');
 module.exports.PlayFairCipher=require('./Cipher/PlayFairCipher');

--- a/test/AffineCipher.test.js
+++ b/test/AffineCipher.test.js
@@ -1,0 +1,15 @@
+const assert=require('assert');
+const AffineCipher=require('../src/Cipher/AffineCipher');
+
+describe("Affine Cipher Test", () => {
+    it("Text with spaces", () => {
+        assert.strictEqual(AffineCipher("HELLO WORLD",5,3),"MXGGVJVKGS");
+    });
+    it("Text with different cases", () => {
+        assert.strictEqual(AffineCipher("Hello World",5,3),"MXGGVJVKGS");
+    });
+    it("Text with same cases without spaces", () => {
+        assert.strictEqual(AffineCipher("IAMPLAINTEXT",6,2),"YCWOQCYCMAKM");
+    });
+    
+})


### PR DESCRIPTION
# Affine Cipher
The affine cipher is a type of monoalphabetic substitution cipher, where each letter in an alphabet is mapped to its numeric equivalent, encrypted using a simple mathematical function, and converted back to a letter.
It is based on the formula **(ax + b) mod m**

**Things needed:**
- [x] Implementation
- [x] Documentation
- [x] Unit test